### PR TITLE
Multiple group code configuration.

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,7 +26,9 @@ final class Configuration implements ConfigurationInterface
             ->scalarNode('base_url')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('system_key')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('system_password')->isRequired()->cannotBeEmpty()->end()
-            ->scalarNode('group_code')->isRequired()->cannotBeEmpty()->end();
+            ->arrayNode('group_code')
+                ->scalarPrototype()->end()
+            ->isRequired()->cannotBeEmpty()->end();
 
         return $treeBuilder;
     }

--- a/src/Exception/NotificationException.php
+++ b/src/Exception/NotificationException.php
@@ -45,4 +45,9 @@ final class NotificationException extends Exception
             sprintf('Wrong status code from CNS: %s', $statusCode)
         );
     }
+
+    public static function unknownGroupCode(string $groupCode): self
+    {
+        return new self(sprintf('Unknown gropu code: \'%s\'', $groupCode));
+    }
 }

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -28,6 +28,8 @@ final class NotificationService implements NotificationServiceInterface
 {
     private const API_ENDPOINT_PATTERN = '%s/v1/notifications?clientSystemKey=%s&clientSystemPassword=%s';
 
+    public const GROUP_CODE_DEFAULT = 'default';
+
     /**
      * @var array<string, string>
      */
@@ -43,8 +45,13 @@ final class NotificationService implements NotificationServiceInterface
         $this->configuration = $parameterBag->get('cns_client');
     }
 
-    public function send(NotificationInterface $notification): int
+    public function send(NotificationInterface $notification, string $groupCode = self::GROUP_CODE_DEFAULT): int
     {
+        if(!array_key_exists($groupCode, $this->configuration['group_code']))
+        {
+            throw NotificationException::unknownGroupCode($groupCode);
+        }
+
         try {
             $response = $this
                 ->httpClient
@@ -58,7 +65,7 @@ final class NotificationService implements NotificationServiceInterface
                     ),
                     [
                         'json' => [
-                            'notificationGroupCode' => $this->configuration['group_code'],
+                            'notificationGroupCode' => $this->configuration['group_code'][$groupCode],
                             'recipients' => $notification->getRecipients(),
                             'defaultContent' => $notification->getContent(),
                         ],

--- a/src/Service/NotificationServiceInterface.php
+++ b/src/Service/NotificationServiceInterface.php
@@ -19,5 +19,8 @@ interface NotificationServiceInterface
     /**
      * @throws NotificationException
      */
-    public function send(NotificationInterface $notification): int;
+    public function send(
+        NotificationInterface $notification,
+        string $groupCode = NotificationService::GROUP_CODE_DEFAULT
+    ): int;
 }

--- a/tests/Service/NotificationServiceTest.php
+++ b/tests/Service/NotificationServiceTest.php
@@ -209,7 +209,7 @@ final class NotificationServiceTest extends TestCase
             ->method('get')
             ->with('cns_client')
             ->willReturn([
-                'group_code' => 'group_code',
+                'group_code' => ['default' => 'group_code'],
                 'base_url' => 'https://example.com',
                 'system_key' => 'system_key',
                 'system_password' => 'system_password',


### PR DESCRIPTION
This PR

- [x]
- [ ]
- [ ]

Follows #. Related to #. Fixes #.

Dears,

I have changed configuration structure and interface of NotificationService, to allow use multiple cns_group.
this patch will affect only existing configurations, but I leave there a default key, in send method, which means the source code of existing application wont be affected.

Kind Regards
